### PR TITLE
Feature/table constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,19 @@ df = dataset("datasets", "attitude")
 cols = []
 for header in names(df)
     x = df[header]
-    stats = OrderedDict("N"     => length(x),
-                        "Mean"  => mean(x),
-                        "Std"   => std(x),
-                        "Min"   => minimum(x),
-                        "Max"   => maximum(x))
-    push!(cols, Table(header, stats))
+    stats = TableCol(header,
+                     "N"     => length(x),
+                     "Mean"  => mean(x),
+                     "Std"   => std(x),
+                     "Min"   => minimum(x),
+                     "Max"   => maximum(x))
+    push!(cols, stats)
 end
 ```
+The base unit of `TexTables` is the `TableCol` type -- it represents a
+header and an OrderedDict of keys and values using special indices that
+allow the user to easily combine tables together.
+
 Each entry of `cols` is it's own table, which we can view in the REPL:
 ```julia
 julia> cols[1]
@@ -110,7 +115,7 @@ m5 = lm(@formula( Rating ~ 1 + Raises + Learning + Privileges
 We can view any one of these as it's own table with the same kind of
 `Table` constructor as before:
 ```julia
-julia> t1 = Table("(1)", m1)
+julia> t1 = TableCol("(1)", m1)
             |   (1)
 -----------------------
 (Intercept) | 19.978
@@ -123,11 +128,11 @@ julia> t1 = Table("(1)", m1)
 ```
 We can combine them together with their own special names
 ```julia
-julia> reg_table = hcat(Table("(1)", m1),
-                        Table("(2)", m2),
-                        Table("(3)", m3),
-                        Table("(4)", m4),
-                        Table("(5)", m5))
+julia> reg_table = hcat(TableCol("(1)", m1),
+                        TableCol("(2)", m2),
+                        TableCol("(3)", m3),
+                        TableCol("(4)", m4),
+                        TableCol("(5)", m5))
            |   (1)    |   (2)    |   (3)    |   (4)   |   (5)
 ------------------------------------------------------------------
 (Intercept) | 19.978   | 15.809   | 14.167   | 11.834  | 11.011
@@ -167,11 +172,11 @@ together under a single heading, and the last two were separate.  We
 could instead construct each group separately and then combine them
 together with the `join_table` function:
 ```julia
-group1 = hcat(  Table("(1)", m1),
-                Table("(2)", m2),
-                Table("(3)", m3))
-group2 = hcat(  Table("(1)", m4),
-                Table("(2)", m5))
+group1 = hcat(  TableCol("(1)", m1),
+                TableCol("(2)", m2),
+                TableCol("(3)", m3))
+group2 = hcat(  TableCol("(1)", m4),
+                TableCol("(2)", m5))
 grouped_table = join_table( "Group 1"=>group1,
                             "Group 2"=>group2)
 ```

--- a/src/FormattedNumbers.jl
+++ b/src/FormattedNumbers.jl
@@ -60,6 +60,7 @@ struct FNum{T} <: FormattedNumber{T}
     end
 end
 
+==(x1::FNum, x2::FNum) = x1.val == x2.val && x1.format == x2.format
 
 struct FNumSE{T} <: FormattedNumber{T}
     val::T
@@ -74,6 +75,10 @@ struct FNumSE{T} <: FormattedNumber{T}
     end
 end
 
+==(x1::FNumSE, x2::FNumSE) =   x1.val == x2.val &&
+                               x1.se  == x2.se  &&
+                               x1.format == x2.format &&
+                               x1.format_se == x2.format_se
 
 function FormattedNumber(val::T, format::String=default_fmt(T)) where T
     return FNum(val, format)
@@ -123,4 +128,8 @@ Base.promote_rule(::Type{FNumSE{T}}, ::Type{FNum{S}}) where {T,S} = FNumSE
 value(x::FormattedNumber)   = format(x.format, x.val)
 se(x::FNumSE)               = format("($(x.format_se))", x.se)
 se(x::FNum)                 = ""
+
+
+
+
 

--- a/src/Printing.jl
+++ b/src/Printing.jl
@@ -2,8 +2,6 @@
 #################### Printing ##########################################
 ########################################################################
 
-import Base: show, size
-
 function getindex(t::IndexedTable, row)
     output = []
     for col in t.columns

--- a/src/Printing.jl
+++ b/src/Printing.jl
@@ -183,7 +183,15 @@ function body(t::IndexedTable{N,M}) where {N,M}
     return output
 end
 
-show(io::IO, t::IndexedTable{N,M}) where {N,M} = print(io, head(t)*body(t))
+show(io::IO, t::IndexedTable{N,M}) where {N,M} = begin
+    if all(size(t) .> 0)
+        print(io, head(t)*body(t))
+    else
+        print(io, "IndexedTable{$N,$M} of size $(size(t))")
+    end
+end
+
+
 ########################################################################
 #################### Latex Table Output ################################
 ########################################################################

--- a/src/Public.jl
+++ b/src/Public.jl
@@ -1,9 +1,0 @@
-
-"""
-```
-
-```
-"""
-function Table(args...)
-    return TableCol(args...) |> IndexedTable
-end

--- a/src/TableCol.jl
+++ b/src/TableCol.jl
@@ -1,5 +1,3 @@
-import Base: isless, ==
-
 Idx{N}      = NTuple{N, Int}
 Name{N}     = NTuple{N, Symbol}
 
@@ -109,20 +107,29 @@ function TableCol(header, kv::Associative, kp::Associative)
                          for (i, (key, val)) in enumerate(kv)))
 end
 
-function TableCol(header, keys, values)
+function TableCol(header, keys::Vector, values::Vector)
 
     pairs = [TableIndex(i, key)=>FormattedNumber(val)
              for (i, (key, val)) in enumerate(zip(keys, values))]
     TableCol(header, OrderedDict(pairs...))
 end
 
-function TableCol(header, keys, values, precision)
+function TableCol(header, keys::Vector, values::Vector,
+                  precision::Vector)
 
     pairs  = [ TableIndex(i, key)=>FormattedNumber(val, se)
                for (i, (key, val, se))
                in enumerate(zip(keys, values, precision))]
     data = OrderedDict(pairs...)
     return TableCol(header, data)
+end
+
+convert(::Type{FormattedNumber}, x) = FormattedNumber(x)
+convert(::Type{FormattedNumber}, x::FormattedNumber) = x
+
+Entry = Pair{T, K} where {T<:Printable, K<:Union{Printable, Number}}
+function TableCol(header::Printable, pairs::Vararg{Entry})
+    return TableCol(header, OrderedDict(pairs))
 end
 
 ########################################################################

--- a/src/TableCol.jl
+++ b/src/TableCol.jl
@@ -58,8 +58,6 @@ function isless_group(index1::TableIndex{N}, index2::TableIndex{N},
     return false
 end
 
-
-
 ########################################################################
 #################### Columns ###########################################
 ########################################################################
@@ -72,6 +70,9 @@ end
 function TableCol(header::String)
     return TableCol(header, TableDict())
 end
+
+TableCol(header::String) = TableCol(TableIndex(1, header),
+                                    TableDict{1, FormattedNumber}())
 
 TableCol(x::TableCol; kwargs...) = x
 
@@ -101,17 +102,20 @@ end
 
 function TableCol(header, kv::Associative, kp::Associative)
     TableCol(header,
-             OrderedDict(TableIndex(i, key)=>(key in keys(kp)) ?
-                         FormattedNumber(val, kp[key]) :
-                         FormattedNumber(val)
-                         for (i, (key, val)) in enumerate(kv)))
+             OrderedDict{TableIndex{1}, FormattedNumber}(
+                TableIndex(i, key)=>(key in keys(kp)) ?
+                                    FormattedNumber(val, kp[key]) :
+                                    FormattedNumber(val)
+                                    for (i, (key, val))
+                                    in enumerate(kv)))
 end
 
-function TableCol(header, keys::Vector, values::Vector)
+function TableCol(header, ks::Vector, vs::Vector)
 
     pairs = [TableIndex(i, key)=>FormattedNumber(val)
-             for (i, (key, val)) in enumerate(zip(keys, values))]
-    TableCol(header, OrderedDict(pairs...))
+             for (i, (key, val)) in enumerate(zip(ks, vs))]
+    TableCol(header,
+             OrderedDict{TableIndex{1}, FormattedNumber}(pairs...))
 end
 
 function TableCol(header, keys::Vector, values::Vector,
@@ -127,7 +131,8 @@ end
 convert(::Type{FormattedNumber}, x) = FormattedNumber(x)
 convert(::Type{FormattedNumber}, x::FormattedNumber) = x
 
-Entry = Pair{T, K} where {T<:Printable, K<:Union{Printable, Number}}
+Entry = Pair{T, K} where {T<:Printable, K<:Union{Printable, Number,
+                                                 NTuple{2,Number}}}
 function TableCol(header::Printable, pairs::Vararg{Entry})
     return TableCol(header, OrderedDict(pairs))
 end
@@ -192,7 +197,7 @@ end
 
 function setindex!(col::TableCol{1,N}, value, key::Printable) where N
     skey        = Symbol(key)
-    loc         = string_lookup(col, skey)
+    loc         = name_lookup(col, skey)
     col_index   = keys(col.data) |> collect
     if length(loc) > 1
         throw(KeyError("""
@@ -202,7 +207,9 @@ function setindex!(col::TableCol{1,N}, value, key::Printable) where N
     elseif length(loc) == 0
         # We need to insert it at a new position
         index   = get_idx(col_index, 1)
-        new_idx = maximum(index) + 1
+        new_idx =   length(index) > 0  ?
+                    maximum(index) + 1 :
+                    1
         col[TableIndex(new_idx, skey)] = value
     else
         col[col_index[loc[1]]] = value

--- a/src/TexTables.jl
+++ b/src/TexTables.jl
@@ -16,14 +16,17 @@ export IndexedTable, append_table, join_table, promote_rule
 
 # Import from base to extend
 import Base.getindex, Base.setindex!, Base.push!
+import Base: isless, ==
+import Base: getindex, size, hcat, vcat, convert, promote_rule
+import Base: show, size
 
+# Need this abstract type
 abstract type TexTable end
 
 include("FormattedNumbers.jl")
 include("TableCol.jl")
 include("CompositeTable.jl")
 include("Printing.jl")
-include("Public.jl")
 include("StatsModelsInterface.jl")
 
 end # module

--- a/test/composite_tables.jl
+++ b/test/composite_tables.jl
@@ -2,9 +2,9 @@
 srand(1234)
 x  = randn(10)
 y  = [Symbol(:key, i) for i=1:10]
-t1 = Table("test", y, x)
-t2 = Table("test2", y[2:9], x[2:9])
-t3 = Table("test3", y, x, randn(10) .|> abs .|> sqrt)
+t1 = TableCol("test", y, x)
+t2 = TableCol("test2", y[2:9], x[2:9])
+t3 = TableCol("test3", y, x, randn(10) .|> abs .|> sqrt)
 sub_tab1= hcat(t1, t2, t3)
 
 # Composite Table Checks

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -38,15 +38,15 @@
         srand(1234)
         x  = randn(10)
         y  = [Symbol(:key, i) for i=1:10]
-        t1 = Table("test", y, x)
-        t2 = Table("test2", y[2:9], x[2:9])
-        t3 = Table("test3", y, x, randn(10) .|> abs .|> sqrt)
+        t1 = TableCol("test", y, x)
+        t2 = TableCol("test2", y[2:9], x[2:9])
+        t3 = TableCol("test3", y, x, randn(10) .|> abs .|> sqrt)
         sub_tab1= hcat(t1, t2, t3)
 
         # Composite Table Checks
-        t4 = Table("test" , Dict("Fixed Effects"=>"Yes"))
-        t5 = Table("test2", Dict("Fixed Effects"=>"No"))
-        t6 = Table("test3", Dict("Fixed Effects"=>"Yes"))
+        t4 = TableCol("test" , Dict("Fixed Effects"=>"Yes"))
+        t5 = TableCol("test2", Dict("Fixed Effects"=>"No"))
+        t6 = TableCol("test3", Dict("Fixed Effects"=>"Yes"))
         c1 = append_table(t1, t4)
         c2 = append_table(t2, t5)
         c3 = append_table(t3, t6)

--- a/test/tablecol.jl
+++ b/test/tablecol.jl
@@ -1,35 +1,94 @@
 
+function test_constructor(name, x, y)
+    pairs = Pair.(x,y)
+    col = TableCol(name, x, y)
+    @test col isa TableCol{1,1}
+
+    # Check that all the constructors work
+    @test begin
+        col2 = TableCol(name, OrderedDict(pairs))
+        col2 == col
+    end
+
+    @test begin
+        col3 = TableCol(name, pairs...)
+        col3 == col
+    end
+
+    # Build in a loop
+    @test begin
+        col4 = TableCol(name)
+        for (key, val) in zip(x,y)
+            col4[key] = val
+        end
+        col4 == col
+    end
+end
+
+# This version does it with precisions
+function test_constructor(name, x, y, p)
+    pairs = Pair.(x,tuple.(y,p))
+
+    col = TableCol(name, x, y, p)
+    @test col isa TableCol{1,1}
+
+    # Check that all the constructors work
+    @test begin
+        col2 = TableCol(name, OrderedDict(pairs))
+        col2 == col
+    end
+
+    @test begin
+        col3 = TableCol(name, pairs...)
+        col3 == col
+    end
+
+    @test begin
+        p1  = Pair.(x, y) |> OrderedDict
+        p2  = Pair.(x, p) |> OrderedDict
+        col4 = TableCol(name, p1, p2)
+        col4 == col
+    end
+
+    # Build in a loop
+    @test begin
+        col5 = TableCol(name)
+        for (key, val, se) in zip(x,y,p)
+            col5[key] = val, se
+        end
+        col5 == col
+    end
+end
 
 @testset "Constructing TableCols" begin
+
     @testset "Integer Values" begin
         # Data
         name = "test"
         x = ["key1", "key2", "key3"]
         y = [1, 2, 3]
 
-        # Simple way to construct it
-        col = TableCol(name, x, y)
-        @test col isa TableCol{1,1}
-
-        # Check that all the constructors work
-        col2 = TableCol(name, OrderedDict(Pair.(x,y)))
-        @test col2 == col
+        test_constructor(name, x, y)
     end
 
-    @testset "Float Values" begin
+    @testset "Float Values with Precision" begin
         # Data
         name = "test"
         x = ["key1", "key2", "key3"]
         y = [1.0, 2.0, 3.0]
         p = [.2, .3, .3]
 
-        # Simple way to construct it
-        col = TableCol(name, x, y)
-        @test col isa TableCol{1,1}
+        test_constructor(name, x, y, p)
+    end
 
-        # Check that all the constructors work
-        col2 = TableCol(name, OrderedDict(Pair.(x,y)))
-        @test_skip col2 == col
+    @testset "Construct With Mixed Types" begin
+
+        name = "foo"
+        x = ["key1", "key2", "key3", "key4"]
+        y = [1, 2.2, (3.2, .24), "bar"]
+
+        test_constructor(name, x, y)
 
     end
+
 end


### PR DESCRIPTION
# Feature Addition: New TableCol Constructor on Pairs

Now we can construct TableCol's with the syntax
```
TableCol(header, key1=>val1, key2=>val2, ...)
```

Also, `TableCol` and `IndexedTable` are both subtypes of the same abstract type `TexTable`. Concatenation methods have been updated to accept any `TexTable`, and will automatically promote `TableCol` as needed.

Removed old `Table` syntax for constructing TableCols -- it's redundant and unnecessary now.  It's better to be explicit when you're constructing a Column and just promote it up as needed.  