### PR TITLE
Fix Export of setcoef!, setmeta!, setstats! bindings

### DIFF
--- a/src/TexTables.jl
+++ b/src/TexTables.jl
@@ -16,7 +16,7 @@ export FormattedNumber, FNum, FNumSE, @fmt, TableCol, star!
 export TableCol, Table, TexTable, get_vals
 export IndexedTable, append_table, join_table, promote_rule
 export to_tex, to_ascii, write_tex, regtable
-export addcoef!, addmeta!, addstats!, RegCol
+export setcoef!, setmeta!, setstats!, RegCol
 
 # Import from base to extend
 import Base.getindex, Base.setindex!, Base.push!


### PR DESCRIPTION
In previous release, forgot to export set[block]! bindings (after the name change from add[block]! to set[block]!).  Everything is still there, so there's no need to push this out until the next release: people can just import it manually for now.  But this should be fixed.  