### PR TITLE
add double line as default border

### DIFF
--- a/src/Printing.jl
+++ b/src/Printing.jl
@@ -394,7 +394,7 @@ function top_matter(printer::TablePrinter{N,M}) where {N,M}
         for i=1:N
             align *= empty_row(t, i) ? "" : "r"
         end
-
+end
         for (i, pair) in enumerate(col_schema[max(M-1,1)])
             align *= (M > 1) | (i==1) ? "|" : ""
             align *= "c"^pair.second

--- a/src/Printing.jl
+++ b/src/Printing.jl
@@ -405,7 +405,8 @@ function top_matter(printer::TablePrinter{N,M}) where {N,M}
         elseif border == :single
             return "\\begin{tabular}{$align}\n\\toprule\n"
         elseif border == :none
-            return "\\begin{tabular}{$align}\n\\hline\\hline\n"
+            return "\\begin{tabular}{$align}\n\\toprule\n"
+            @warn("default border will change to double in future releases")
     end
 end
 
@@ -672,7 +673,8 @@ function foot(t::TablePrinter)
     elseif border == :single
         table_type == :latex && return "\\bottomrule\n\\end{tabular}"
     elseif border == :none
-        table_type == :latex && return "\\hline\\hline\n\\end{tabular}"
+        table_type == :latex && return "\\bottomrule\n\\end{tabular}"
+        @warn("default border will change to double in future releases")
 end
 
 

--- a/src/Printing.jl
+++ b/src/Printing.jl
@@ -675,6 +675,7 @@ function foot(t::TablePrinter)
     elseif border == :none
         table_type == :latex && return "\\bottomrule\n\\end{tabular}"
         @warn("default border will change to double in future releases")
+    end
 end
 
 

--- a/src/Printing.jl
+++ b/src/Printing.jl
@@ -401,11 +401,11 @@ function top_matter(printer::TablePrinter{N,M}) where {N,M}
         end
 
         if border == :double
-            return "\\begin{tabular}{$align}\n\\hline\hline\n"
+            return "\\begin{tabular}{$align}\n\\hline\\hline\n"
         elseif border == :single
             return "\\begin{tabular}{$align}\n\\toprule\n"
         elseif border == :none
-            return "\\begin{tabular}{$align}\n\\hline\hline\n"
+            return "\\begin{tabular}{$align}\n\\hline\\hline\n"
     end
 end
 
@@ -668,11 +668,11 @@ function foot(t::TablePrinter)
     @unpack table_type = t.params
     table_type == :ascii && return ""
     if border == :double
-        table_type == :latex && return "\\hline\hline\n\\end{tabular}"
+        table_type == :latex && return "\\hline\\hline\n\\end{tabular}"
     elseif border == :single
         table_type == :latex && return "\\bottomrule\n\\end{tabular}"
     elseif border == :none
-        table_type == :latex && return "\\hline\hline\n\\end{tabular}"
+        table_type == :latex && return "\\hline\\hline\n\\end{tabular}"
 end
 
 

--- a/src/Printing.jl
+++ b/src/Printing.jl
@@ -35,9 +35,10 @@ end
     star::Bool          = true
     sep::String         = default_sep(table_type)
     align::String       = "c"
-    TableParams(pad, table_type, se_pos, star, sep, align) = begin
+    border::Symbol      = :double
+    TableParams(pad, table_type, se_pos, star, sep, align, border) = begin
         # Argument Checking
-        return new(pad, table_type, se_pos, star, sep, align)
+        return new(pad, table_type, se_pos, star, sep, align, border)
     end
 end
 
@@ -399,7 +400,12 @@ function top_matter(printer::TablePrinter{N,M}) where {N,M}
             align *= "c"^pair.second
         end
 
-        return "\\begin{tabular}{$align}\n\\toprule\n"
+        if border == :double
+            return "\\begin{tabular}{$align}\n\\hline\hline\n"
+        elseif border == :single
+            return "\\begin{tabular}{$align}\n\\toprule\n"
+        elseif border == :none
+            return "\\begin{tabular}{$align}\n\\hline\hline\n"
     end
 end
 
@@ -657,11 +663,16 @@ end
 ########################################################################
 #################### Footer ############################################
 ########################################################################
-
+# Footer edited to produce double horizontal
 function foot(t::TablePrinter)
     @unpack table_type = t.params
     table_type == :ascii && return ""
-    table_type == :latex && return "\\bottomrule\n\\end{tabular}"
+    if border == :double
+        table_type == :latex && return "\\hline\hline\n\\end{tabular}"
+    elseif border == :single
+        table_type == :latex && return "\\bottomrule\n\\end{tabular}"
+    elseif border == :none
+        table_type == :latex && return "\\hline\hline\n\\end{tabular}"
 end
 
 


### PR DESCRIPTION
This pull request addresses issue #6 to add a default option `border :double` for latex table borders `\hline\hline`. I made this the default option, but I also included a `border :single` option to allow the user to keep `\toprule' and `\bottomrule' if they want.

I ran runtests.jl and there were no errors.

Let me know if there is anything I need to fix or tests that I should create. 