### PR TITLE
Fix join_table for 4+ pairs

### DIFF
--- a/src/CompositeTable.jl
+++ b/src/CompositeTable.jl
@@ -184,8 +184,8 @@ function join_table(p1::Pair{P1,T1},
     return join_table(join_table(p1, p2), p3, args...)
 end
 
-join_table(t1::IndexedTable, p2::Pair{P2,T2}) where {P2, T2} = begin
-    join_table(t1, join_table(p2))
+join_table(t1::IndexedTable, p2::Pair{P2,T2}, args...) where {P2, T2} = begin
+    join_table(join_table(t1, join_table(p2)), args...)
 end
 
 join_table(p2::Pair{P2,T2},t1::IndexedTable) where {P2, T2} = begin

--- a/src/CompositeTable.jl
+++ b/src/CompositeTable.jl
@@ -184,12 +184,16 @@ function join_table(p1::Pair{P1,T1},
     return join_table(join_table(p1, p2), p3, args...)
 end
 
-join_table(t1::IndexedTable, p2::Pair{P2,T2}, args...) where {P2, T2} = begin
-    join_table(join_table(t1, join_table(p2)), args...)
+join_table(t1::IndexedTable, p2::Pair{P2,T2}) where {P2, T2} = begin
+    join_table(t1, join_table(p2))
 end
 
 join_table(p2::Pair{P2,T2},t1::IndexedTable) where {P2, T2} = begin
     join_table(join_table(p2), t1)
+end
+
+join_table(t1::IndexedTable, p2::Pair{P2,T2}, args...) where {P2, T2} = begin
+    join_table(join_table(t1, p2), args...)
 end
 
 # Appending

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using   CSV
 include("helper.jl")
 
 tests = [   "tablecol", "composite_tables", "indexing", "printing",
-            "examples", "quicktools", "formatted_numbers"]
+            "examples", "quicktools", "formatted_numbers", "table_joins"]
 
 @testset "TexTables" begin
     for testsuite in tests

--- a/test/table_joins.jl
+++ b/test/table_joins.jl
@@ -1,4 +1,5 @@
 @testset "Table Joins for Several Pairs" begin
+    import TexTables: IndexedTable, TableCol, join_table
     # Tests for issue in PR #28 (makes sure that the recursive table join
     # implementation on pairs works properly)
     n = 5

--- a/test/table_joins.jl
+++ b/test/table_joins.jl
@@ -1,0 +1,19 @@
+@testset "Table Joins for Several Pairs" begin
+    # Tests for issue in PR #28 (makes sure that the recursive table join
+    # implementation on pairs works properly)
+    n = 5
+    keys = ["x$i" for i in 1:4]
+    cols = Vector{IndexedTable{1,1}}(undef, 4)
+    for j in 1:4
+        cols[j] = hcat(TableCol("mean", keys, rand(n)),
+                       TableCol("std", keys, rand(n)))
+    end
+    
+    # Test that the construction doesn't error out with 4 pairs
+    for k in 1:4
+        @test begin
+            tab = join_table(collect("($j)" => cols[j] for j in 1:k)...)
+            true
+        end
+    end
+end

--- a/test/table_joins.jl
+++ b/test/table_joins.jl
@@ -3,7 +3,7 @@
     # Tests for issue in PR #28 (makes sure that the recursive table join
     # implementation on pairs works properly)
     n = 5
-    keys = ["x$i" for i in 1:4]
+    keys = ["x$i" for i in 1:5]
     cols = Vector{IndexedTable{1,1}}(undef, 4)
     for j in 1:4
         cols[j] = hcat(TableCol("mean", keys, rand(n)),


### PR DESCRIPTION
Hey Jacob! I noticed that `join_table` was working for me with three `Pair`s but not with four. As an example, here are four tables with five rows and two columns each.

```
using TexTables

n = 5
keys = ["x$i" for i in 1:5]
cols = Vector{IndexedTable{1,1}}(undef, 4)
for j in 1:4
    cols[j] = hcat(TableCol("mean", keys, rand(n)),
                   TableCol("std", keys, rand(n)))
end
```

Calling `join_table` on three of the tables works as expected:
```
julia> tab3 = join_table(collect("($j)" => cols[j] for j in 1:3)...)
   |      (1)      |      (2)      |      (3)
   | mean  |  std  | mean  |  std  | mean  |  std
---------------------------------------------------
x1 | 0.371 | 0.733 | 0.844 | 0.222 | 0.458 | 0.950
x2 | 0.759 | 0.775 | 0.209 | 0.440 | 0.713 | 0.732
x3 | 0.089 | 0.359 | 0.197 | 0.236 | 0.774 | 0.845
x4 | 0.835 | 0.969 | 0.366 | 0.755 | 0.989 | 0.015
x5 | 0.209 | 0.707 | 0.539 | 0.554 | 0.929 | 0.993
```

But with four, I get the following error:
```
julia> tab4 = join_table(collect("($j)" => cols[j] for j in 1:4)...)
ERROR: MethodError: no method matching join_table(::IndexedTable{1,2}, ::Pair{String,IndexedTable{1,1}}, ::Pair{String,IndexedTable{1,1}})
Closest candidates are:
  join_table(::Pair{P1,T1}, ::Pair{P2,T2}, ::Pair{P3,T3}, ::Any...) where {P1<:Union{String, Symbol}, P2<:Union{String, Symbol}, P3<:Union{String, Symbol}, T1<:TexTable, T2<:TexTable, T3<:TexTable} at /Users/pearl/.julia/dev/TexTables/src/CompositeTable.jl:178
  join_table(::IndexedTable, ::Pair{P2,T2}) where {P2, T2} at /Users/pearl/.julia/dev/TexTables/src/CompositeTable.jl:187
  join_table(::IndexedTable) at /Users/pearl/.julia/dev/TexTables/src/CompositeTable.jl:142
  ...
Stacktrace:
 [1] join_table(::Pair{String,IndexedTable{1,1}}, ::Pair{String,IndexedTable{1,1}}, ::Pair{String,IndexedTable{1,1}}, ::Pair{String,IndexedTable{1,1}}) at /Users/pearl/.julia/dev/TexTables/src/CompositeTable.jl:184
 [2] top-level scope at REPL[19]:1
```

To fix this, I added `args...` to the `join_table(::IndexedTable, ::Pair{P2,T2}) where {P2, T2}` method.