### PR TITLE
Remap column headers in vcat

### DIFF
--- a/test/composite_tables.jl
+++ b/test/composite_tables.jl
@@ -7,7 +7,10 @@ y  = [Symbol(:key, i) for i=1:10]
 t1 = TableCol("test", y, x)
 t2 = TableCol("test2", y[2:9], x[2:9])
 t3 = TableCol("test3", y, x, randn(10) .|> abs .|> sqrt)
-sub_tab1= hcat(t1, t2, t3)
+sub_tab1 = hcat(t1, t2, t3)
+sub_tab2 = vcat(t1, t2, t3)
+@test sub_tab1.col_index == map(col -> col.header, sub_tab1.columns)
+@test sub_tab2.col_index == map(col -> col.header, sub_tab2.columns)
 
 # Composite Table Checks
 t4 = TableCol("test" , Dict("Fixed Effects"=>"Yes")) |> IndexedTable
@@ -15,10 +18,10 @@ t5 = TableCol("test2", Dict("Fixed Effects"=>"No"))  |> IndexedTable
 t6 = TableCol("test3", Dict("Fixed Effects"=>"Yes")) |> IndexedTable
 
 # Build the table two different ways
-sub_tab2= hcat(t4, t5, t6)
-tab     = vcat(sub_tab1, sub_tab2)
-tab2    = [t1 t2 t3
-           t4 t5 t6]
+sub_tab3 = hcat(t4, t5, t6)
+tab      = vcat(sub_tab1, sub_tab3)
+tab2     = [t1 t2 t3
+            t4 t5 t6]
 @test to_ascii(tab) == to_ascii(tab2)
 
 c1 = append_table(t1, t4)


### PR DESCRIPTION
Hey Jacob! This is the first of two pull requests about creating composite tables. Suppose we start with:

```julia
using TexTables

m, n = 5, 4
keys = ["x$i" for i in 1:m]
cols = map(j -> TableCol("test$j", keys, rand(m)), 1:n)
```

This pull request adds column header remapping to `vcat`. `hcat` already does this:
```julia
julia> t1 = hcat(cols...);

julia> t1.col_index == [col.header for col in t1.columns]
true
```

However, for `vcat`, the column index doesn't match the column headers, so that subsequent calls to `hcat` and `join_table` throw errors:
```julia
julia> t2 = vcat(cols...);

julia> t2.col_index
4-element Vector{TexTables.TableIndex{1}}:
 TexTables.TableIndex{1}((1,), (:test1,))
 TexTables.TableIndex{1}((2,), (:test2,))
 TexTables.TableIndex{1}((3,), (:test3,))
 TexTables.TableIndex{1}((4,), (:test4,))

julia> [col.header for col in t2.columns]
4-element Vector{TexTables.TableIndex{1}}:
 TexTables.TableIndex{1}((1,), (:test1,))
 TexTables.TableIndex{1}((1,), (:test2,))
 TexTables.TableIndex{1}((1,), (:test3,))
 TexTables.TableIndex{1}((1,), (:test4,))

julia> hcat(t1, t2)
ERROR: KeyError: key TexTables.TableIndex{1}((1,), (:test2,)) not found

julia> join_table(t1, t2)
ERROR: KeyError: key TexTables.TableIndex{1}((1,), (:test2,)) not found
```

Under the new behavior, `t2.col_index` should match `[col.header for col in t2.columns]`.