### PR TITLE
Join and append tables non-recursively

### DIFF
--- a/test/composite_tables.jl
+++ b/test/composite_tables.jl
@@ -24,5 +24,12 @@ tab2    = [t1 t2 t3
 c1 = append_table(t1, t4)
 c2 = append_table(t2, t5)
 c3 = append_table(t3, t6)
+@test c1 isa IndexedTable{2,1}
+
+c4 = append_table(t1, t4, t4)
+@test c4 isa IndexedTable{2,1}
+
+c5 = join_table(t1, t2, t3)
+@test c5 isa IndexedTable{1,2}
 
 compare_file(1, to_tex(sub_tab1))


### PR DESCRIPTION
This is my second pull request about creating composite tables. Here, I re-implement `join_table` and `append_table` non-recursively, so that joining/appending >2 tables only increases the dimension by 1. Under the old behavior, if we define `t3` and `t4` below as

```julia
using TexTables

m, n = 5, 4
keys = ["x$i" for i in 1:m]
cols = map(j -> TableCol("test$j", keys, rand(m)), 1:n)

t3 = join_table(cols...)
t4 = append_table(cols...)
```

then they have types `IndexedTable{1, 4}` and `IndexedTable{4, 1}`, respectively. Under the new behavior, they will have types `IndexedTable{1, 2}` and `IndexedTable{2, 1}`.